### PR TITLE
fix typo in feature

### DIFF
--- a/.vuepress/theme/components/home/LandingFeature.vue
+++ b/.vuepress/theme/components/home/LandingFeature.vue
@@ -60,7 +60,7 @@ export default {
                 },
                 {
                     title: "Easy to learn",
-                    description: "Flows are in simple, descriptive language defined in YAML;u don't need to be a developer to create a new flow.",
+                    description: "Flows are in simple, descriptive language defined in YAML; you don't need to be a developer to create a new flow.",
                     icon: SchoolOutline
                 },
                 {


### PR DESCRIPTION
There was a typo in Easy to Learn feature on homepage which bothered me. I couldnt find any contribution guideline to fix it properly.