### PR TITLE
Sync listed namespaces

### DIFF
--- a/docs/administrator-guide/configuration/enterprise-edition/workers/README.md
+++ b/docs/administrator-guide/configuration/enterprise-edition/workers/README.md
@@ -40,7 +40,7 @@ For [Bash tasks](/plugins/core/tasks/scripts/io.kestra.core.tasks.scripts.Bash.h
 kestra:
   tasks:
     defaults:
-      - type: org.kestra.core.tasks.scripts.Bash
+      - type: io.kestra.core.tasks.scripts.Bash
         forced: true
         values:
           dockerOptions:

--- a/docs/developer-guide/best-practice/README.md
+++ b/docs/developer-guide/best-practice/README.md
@@ -21,7 +21,7 @@ Here is an example of a taskRun :
 {
   "id": "5cBZ1JF8kim8fbFg13bumX",
   "executionId": "6s1egIkxu3gpzzILDnyxTn",
-  "namespace": "org.kestra.tests",
+  "namespace": "io.kestra.tests",
   "flowId": "each-sequential-nested",
   "taskId": "1-1_return",
   "parentTaskRunId": "5ABxhOwhpd2X8DtwUPKERJ",

--- a/docs/developer-guide/listeners/README.md
+++ b/docs/developer-guide/listeners/README.md
@@ -15,10 +15,10 @@ The result of the tasks will not change the execution status. In most cases,  Li
 listeners:
   - tasks:
       - id: mail
-        type: org.kestra.task.notifications.slack.SlackExecution
+        type: io.kestra.plugin.notifications.slack.SlackExecution
         url: https://hooks.slack.com/services/XXX/YYY/ZZZ
     conditions:
-      - type: org.kestra.core.models.listeners.types.ExecutionStatusCondition
+      - type: io.kestra.core.models.conditions.types.ExecutionStatusCondition
         in:
           - FAILED
 ```


### PR DESCRIPTION
The `org.kestra` namespace is not relevant for the doc anymore. See [#306](https://github.com/kestra-io/kestra/pull/306).

Updated namespaces to the current ones.