### PR TITLE
feat(docs): add a global tasks page

### DIFF
--- a/.vuepress/enhanceApp.js
+++ b/.vuepress/enhanceApp.js
@@ -9,5 +9,6 @@ export default (
 
     router.addRoutes([
         { path: '/blogs/2022-02-01-leroy-merlin-usage-kestra(.*)', redirect: '/blogs/2022-02-22-leroy-merlin-usage-kestra.html' },
+        { path: '/docs/developer-guide/flowable/', redirect: '/docs/developer-guide/tasks/#flowable-tasks'}
     ])
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Kestra is an orchestration and scheduling platform that helps you build, run, sc
 
 ## Principles
 
-- **Simple**: Kestra workflows are written in YAML. It is a declarative syntax that allows you to write even [complex](developer-guide/flowable) workflows.
+- **Simple**: Kestra workflows are written in YAML. It is a declarative syntax that allows you to write even [complex](developer-guide/tasks/README.md#flowable-tasks) workflows.
 - **Extensible**: The entire foundation of Kestra is built upon plugins. You can use an existing plugin from our [plugin library](../plugins) or build your [own](plugin-developer-guide).
 - **Real-time**: Kestra is built with real-time use cases in mind. You can create flows, run them, and see all their logs in real-time.
 - **Scalable**: Kestra's [architecture](architecture) allows scaling according to your workload. The [Enterprise Edition](https://kestra.io/features/enterprise.html) can scale even more thanks to Kafka and Elasticsearch and can handle millions of executions without breaking a sweat.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -50,7 +50,7 @@ Each server component interacts with the Kestra internal components (internal st
 
 ### Executor
 
-The **Executor** handles all executions and [flowable tasks](../developer-guide/flowable). The only goal of the Executor is to receive created executions and look for the next tasks to run. There is no heavy computation required (and no capacity for it) for this server component.
+The **Executor** handles all executions and [flowable tasks](../developer-guide/tasks/README.md#flowable-tasks). The only goal of the Executor is to receive created executions and look for the next tasks to run. There is no heavy computation required (and no capacity for it) for this server component.
 
 The Executor also handles special execution cases:
 - [Listeners](../developer-guide/listeners).

--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -20,14 +20,14 @@ There are two kinds of tasks in Kestra:
 
 ### Runnable Task 
 
-Runnable Tasks handle computational work in the flow. For example, file system operations, API calls, database queries, etc. These tasks can be compute-intensive and are handled by [workers](../architecture/#worker). 
+[Runnable Tasks](../developer-guide/tasks/README.md#runnable-tasks) handle computational work in the flow. For example, file system operations, API calls, database queries, etc. These tasks can be compute-intensive and are handled by [workers](../architecture/#worker). 
 
 By default, Kestra only includes a few Runnable Tasks. However, many of them are available as [plugins](../../plugins/) and if you use our default Docker image plenty of them will be already included.
 
 
 ### Flowable Task
 
-[Flowable Tasks](../developer-guide/flowable) only handle flow logic (branching, grouping, parallel processing, etc.) and start new tasks. For example, the Switch task decides the next task to run based on some inputs. 
+[Flowable Tasks](../developer-guide/tasks/README.md#flowable-tasks) only handle flow logic (branching, grouping, parallel processing, etc.) and start new tasks. For example, the Switch task decides the next task to run based on some inputs. 
 
 A Flowable Task is handled by [executors](../architecture/#executor) and can be called very often. Because of that, these tasks cannot include intensive computations, unlike Runnable Tasks. Most of the common Flowable Tasks are available in the default Kestra installation. 
 

--- a/docs/developer-guide/errors-handling/README.md
+++ b/docs/developer-guide/errors-handling/README.md
@@ -6,7 +6,7 @@ Errors are special branches of your flow where you can define how to handle task
 
 Two kinds of error handlers can be defined:
 * **Global**: error handling global to a flow that must be at the root of the flow.
-* **Local**: error handling local to a [Flowable Task](../flowable), will handle errors for the flowable task and its children.
+* **Local**: error handling local to a [Flowable Task](../tasks/README.md#flowable-tasks), will handle errors for the flowable task and its children.
 
 
 ## Global Error Handler

--- a/docs/developer-guide/flow/README.md
+++ b/docs/developer-guide/flow/README.md
@@ -7,7 +7,7 @@ order: 1
 
 You define a flow thanks to a declarative model in YAML.
 
-A flow must have an identifier (id), a namespace, and a list of tasks.
+A flow must have an identifier (id), a namespace, and a list of [tasks](../tasks/).
 
 A flow can also have [inputs](../inputs/), [listeners](../listeners/), [error handlers](../errors-handling/), and [triggers](../triggers/).
 

--- a/docs/developer-guide/listeners/README.md
+++ b/docs/developer-guide/listeners/README.md
@@ -43,7 +43,7 @@ listeners:
 
 > A list of tasks that will be executed at the end of the flow. The status of these tasks will not impact the main execution and will not change the execution status even if they fail.
 >
-> You can use every tasks you need here, even [Flowable](../flowable).
+> You can use every tasks you need here, even [Flowable](../tasks/README.md#flowable-tasks).
 > All task `id` must be unique for the whole flow even for main `tasks` and `errors`.
 
 

--- a/docs/developer-guide/tasks/README.md
+++ b/docs/developer-guide/tasks/README.md
@@ -2,7 +2,37 @@
 order: 2
 ---
 
-# Flowable Task
+# Tasks
+
+## Runnable Tasks
+
+In Kestra, workloads are done using **Runnable Tasks**.
+
+Runnable Tasks handle computational work in the flow. For example, file system operations, API calls, database queries, etc. These tasks can be compute-intensive and are handled by [workers](../../architecture/#worker).
+
+Each task must have an identifier (id) and a type. The type is a Java Fully Qualified Class Name (FQCN) of the task.
+
+Tasks have properties specific to the type of the task; check each task's documentation for the list of available properties.
+
+Most available tasks are Runnable Tasks except special ones that are [Flowable Tasks](#flowable-tasks); those are explained later on this page.
+
+### Task common properties
+
+The following task properties can be set.
+
+| Field | Description |
+| ---------- | ----------- |
+|`id`|The flow identifier, must be unique inside a flow.|
+|`type`|The Java FQCN of the task.|
+|`description`|The description of the task, more details [here](../documentation/).|
+|`retry`|Task retry behavior, more details [here](../retries/).|
+|`timeout`|Task timeout expressed in [ISO 8601 Durations](https://en.wikipedia.org/wiki/ISO_8601#Durations).|
+|`disabled`|Set it to `true` to disable execution of the task.|
+
+Task properties can be static or dynamic. Dynamic task properties can be set using [variables](../variables/README.md). To know if a task property is dynamic, read the task's documentation.
+
+
+## Flowable Tasks
 
 In Kestra, we orchestrate your workflows using **Flowable Tasks**. These tasks do not compute anything but allow us to build more complex workflows.
 

--- a/docs/developer-guide/variables/README.md
+++ b/docs/developer-guide/variables/README.md
@@ -26,12 +26,12 @@ The following table lists all the default variables available on each execution.
 |  <code v-pre>{{ task.type }}</code> | The current task Type (Java fully qualified class name). |
 |  <code v-pre>{{ taskrun.id }}</code> | The current task run ID. |
 |  <code v-pre>{{ taskrun.startDate }}</code> | The current task run start date. |
-|  <code v-pre>{{ taskrun.parentId }}</code> | The current task run parent identifier. Only available with tasks inside a  ([Flowable Task](../flowable)).|
-|  <code v-pre>{{ taskrun.value }}</code> | The value of the current task run, only available with tasks inside a ([Flowable Task](../flowable)). |
+|  <code v-pre>{{ taskrun.parentId }}</code> | The current task run parent identifier. Only available with tasks inside a  ([Flowable Task](../tasks/README.md#flowable-tasks)).|
+|  <code v-pre>{{ taskrun.value }}</code> | The value of the current task run, only available with tasks inside a ([Flowable Task](../tasks/README.md#flowable-tasks)). |
 |  <code v-pre>{{ taskrun.attemptsCount }}</code> | The number of attempts for the current task (when retry or restart is performed). |
-|  <code v-pre>{{ parent.taskrun.value }}</code> | The value of the closest (first) parent task run [Flowable Task](../flowable), only available with tasks inside a ([Flowable Task](../flowable)). |
-|  <code v-pre>{{ parent.outputs }}</code> | The outputs of the closest (first) parent task run [Flowable Task](../flowable), only available with tasks inside in a ([Flowable Task](../flowable)). |
-|  <code v-pre>{{ parents }}</code> | The list of parent tasks, only available with tasks inside a ([Flowable Task](../flowable)). See [Parents variables](../variables/basic-usage.md#parents-with-flowable-task) for its usage. |
+|  <code v-pre>{{ parent.taskrun.value }}</code> | The value of the closest (first) parent task run [Flowable Task](../tasks/README.md#flowable-tasks), only available with tasks inside a ([Flowable Task](../tasks/README.md#flowable-tasks)). |
+|  <code v-pre>{{ parent.outputs }}</code> | The outputs of the closest (first) parent task run [Flowable Task](../tasks/README.md#flowable-tasks), only available with tasks inside in a ([Flowable Task](../tasks/README.md#flowable-tasks)). |
+|  <code v-pre>{{ parents }}</code> | The list of parent tasks, only available with tasks inside a ([Flowable Task](../tasks/README.md#flowable-tasks)). See [Parents variables](../variables/basic-usage.md#parents-with-flowable-task) for its usage. |
 
 If a [schedule](../triggers/schedule.md) event triggers the flow, these variables are also available:
 

--- a/docs/developer-guide/variables/basic-usage.md
+++ b/docs/developer-guide/variables/basic-usage.md
@@ -222,9 +222,9 @@ In order from highest to lowest precedence:
 - `or`
 
 
-### Parents with [Flowable Task](../flowable).
+### Parents with [Flowable Task](../tasks/README.md#flowable-tasks).
 
-When a task is in a hierarchy of [Flowable Tasks](../flowable), it can be complex to access the
+When a task is in a hierarchy of [Flowable Tasks](../tasks/README.md#flowable-tasks), it can be complex to access the
 `value` of any of its parents because only the `value` of the direct parent task is accessible via `taskrun.value`.
 
 To deal with this, we have included the `parent` and the `parents` variables.

--- a/docs/developer-guide/variables/deprecated-handlebars/use.md
+++ b/docs/developer-guide/variables/deprecated-handlebars/use.md
@@ -110,8 +110,8 @@ tasks:
 
 In this case, you would need to use <code v-pre>{{ (get outputs.t1 taskrun.value).value }}</code>, which means give me from `outputs.t1` the index results from `taskrun.value`.
 
-### With [Flowable Task](../../flowable) nested.
-If you have many [Flowable Tasks](../../flowable), it can be complex to use the `get` function, and moreover, the `taskrun.value` is only available during the direct task from each. If you have any Flowable Tasks after, the `taskrun.value` of the first iteration will be lost (or overwritten). To deal with this, we have included the `parent` & `parents` vars.
+### With [Flowable Task](../../tasks/README.md#flowable-tasks) nested.
+If you have many [Flowable Tasks](../../tasks/README.md#flowable-tasks), it can be complex to use the `get` function, and moreover, the `taskrun.value` is only available during the direct task from each. If you have any Flowable Tasks after, the `taskrun.value` of the first iteration will be lost (or overwritten). To deal with this, we have included the `parent` & `parents` vars.
 
 This is illustrated in the flow below:
 


### PR DESCRIPTION
@tchiotludo I can add a redirect in case we want to keep current SEO rank for the flowable tasks page