### PR TITLE
Update the min-poll-interval default value

### DIFF
--- a/docs/administrator-guide/configuration/databases/README.md
+++ b/docs/administrator-guide/configuration/databases/README.md
@@ -117,7 +117,7 @@ kestra:
   jdbc:
     queues:
       poll-size: 100
-      min-poll-interval: 100ms
+      min-poll-interval: 25ms
       max-poll-interval: 1000ms
       poll-switch-interval: 5s
 


### PR DESCRIPTION
The property has been set to 25ms since https://github.com/kestra-io/kestra/pull/1012/.