### PR TITLE
feat(docs): add overview in doc navigation

### DIFF
--- a/components/docs/RecursiveNavSidebar.vue
+++ b/components/docs/RecursiveNavSidebar.vue
@@ -5,6 +5,17 @@
         class="accordion-collapse"
         :class="activeSlug.includes(parentSlug) ? 'collapse show' : 'collapse'"
     >
+        <!-- Add the index statically to avoid having sub-nav for it-->
+        <div v-if="depthLevel === 1">
+            <ul class="bd-links-nav list-unstyled mb-0">
+                <li class="depth-1 bd-links-group">
+                    <a href="/docs" :class="activeSlug === '/docs' || activeSlug === '/docs/' ? 'active' : ''" class="bd-links-link d-inline-block">
+                        <span class="bold">
+                            👁️‍🗨️ Overview</span>
+                        </a>
+                    </li>
+                </ul>
+        </div>
         <div v-for="item in items">
             <ul class="bd-links-nav list-unstyled mb-0">
                 <li :class="{['depth-' + depthLevel]: true}" class="bd-links-group">


### PR DESCRIPTION
I don't know if it's the best solution but if we add the index as another nav item it will recursively add all items twice so I ends up hardcoding it