### PR TITLE
fix: add a margin to type mark as there can be multiple

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -234,6 +234,7 @@ blockquote.blockquote {
     border-radius: var(--bs-border-radius);
     color: var(--bs-white);
     font-size: $font-size-sm;
+    margin-right: 5px;
 }
 
 .baseline-max-width {


### PR DESCRIPTION
This will add a small margin so when there is multiple types there is a small margin between them.
![image](https://github.com/kestra-io/kestra.io/assets/1819009/2c08b6dd-717b-43c6-9a14-59d9af4f7bbe)
