### PR TITLE
Edit typo in docs about inputs

### DIFF
--- a/content/docs/02.tutorial/02.inputs.md
+++ b/content/docs/02.tutorial/02.inputs.md
@@ -7,13 +7,13 @@ Flows can have Input. They are parameters provided when starting a flow. They he
 ## Defining inputs
 
 We defined Inputs in the `inputs` section of the flow file. They must have a `name` and a `type`.
-You can also set a `default` value.
+You can also set a `defaults` value.
 
 ```yaml
 inputs:
   - name: isTutorial
     type: BOOLEAN
-    default: true
+    defaults: true
 ```
 
 | Type    | Description                                                            |
@@ -40,7 +40,7 @@ In our example, we will provide the URL of the CSV file we want to download in I
 inputs:
   - name: url
     type: STRING
-    default: "https://gist.githubusercontent.com/tchiotludo/2b7f28f4f507074e60150aedb028e074/raw/6b6348c4f912e79e3ffccaf944fd019bf51cba30/conso-elec-gaz-annuelle-par-naf-agregee-region.csv"
+    defaults: "https://gist.githubusercontent.com/tchiotludo/2b7f28f4f507074e60150aedb028e074/raw/6b6348c4f912e79e3ffccaf944fd019bf51cba30/conso-elec-gaz-annuelle-par-naf-agregee-region.csv"
 ```
 
 ::collapse{title="Click here to see the full flow"}
@@ -55,7 +55,7 @@ description: |
 inputs:
   - name: url
     type: STRING
-    default: "https://gist.githubusercontent.com/tchiotludo/2b7f28f4f507074e60150aedb028e074/raw/6b6348c4f912e79e3ffccaf944fd019bf51cba30/conso-elec-gaz-annuelle-par-naf-agregee-region.csv"
+    defaults: "https://gist.githubusercontent.com/tchiotludo/2b7f28f4f507074e60150aedb028e074/raw/6b6348c4f912e79e3ffccaf944fd019bf51cba30/conso-elec-gaz-annuelle-par-naf-agregee-region.csv"
 tasks:
   - id: download
     type: io.kestra.plugin.fs.http.Download


### PR DESCRIPTION
I'm using the `kestra/kestra:latest-full` image. Using `default` for under `inputs` doesn't work, but using `defaults` under `inputs` works. 